### PR TITLE
Changing dead link

### DIFF
--- a/00_rootfs_build.sh
+++ b/00_rootfs_build.sh
@@ -74,7 +74,7 @@ case $DISTRO in
 		ROOTFS="http://archlinuxarm.org/os/ArchLinuxARM-aarch64-latest.tar.gz"
 		;;
 	xenial)
-		ROOTFS="http://cdimage.ubuntu.com/ubuntu-base/xenial/daily/current/xenial-base-arm64.tar.gz"
+		ROOTFS="http://cdimage.ubuntu.com/ubuntu-base/releases/16.04/release/ubuntu-base-16.04-core-arm64.tar.gz"
 		;;
 	sid|jessie)
 		ROOTFS="${DISTRO}-base-arm64.tar.gz"


### PR DESCRIPTION
The previous link was dead, the base URL changed to "http://cdimage.ubuntu.com/ubuntu-base/releases/16.04/release/". I manage to compile it after this change.